### PR TITLE
Uses options.config in new Rollbar()

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -26,7 +26,7 @@ export default defineNuxtPlugin(({ $config }) => {
   }
 
   const rollbar = new Rollbar({
-    ...(options || {}),
+    ...(options?.config || {}),
     accessToken,
   });
 


### PR DESCRIPTION
The Rollbar config was not passed properly.
if config is like {option1, option2}
we would do new Rollbar({config}) instead of new Rollbar({option1, option2})